### PR TITLE
Fixed errors in getting stat

### DIFF
--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -79,7 +79,9 @@ class AudiosetDataset(Dataset):
         # dataset spectrogram mean and std, used to normalize the input
         self.norm_mean = self.audio_conf.get('mean')
         self.norm_std = self.audio_conf.get('std')
-        print('use dataset mean {:.3f} and std {:.3f} to normalize the input'.format(self.norm_mean, self.norm_std))
+        self.get_norm_stats = self.audio_conf.get('get_norm_stats') if self.audio_conf.get('get_norm_stats') else False
+        if not self.get_norm_stats:
+            print('use dataset mean {:.3f} and std {:.3f} to normalize the input'.format(self.norm_mean, self.norm_std))
         # if add noise for data augmentation
         self.noise = self.audio_conf.get('noise')
         if self.noise == True:
@@ -187,8 +189,9 @@ class AudiosetDataset(Dataset):
             fbank = timem(fbank)
         fbank = torch.transpose(fbank, 0, 1)
 
-        # normalize the input
-        fbank = (fbank - self.norm_mean) / (self.norm_std * 2)
+        # normalize the input if not getting the stats for downstream task
+        if not self.get_norm_stats:
+            fbank = (fbank - self.norm_mean) / (self.norm_std * 2)
 
         if self.noise == True:
             fbank = fbank + torch.rand(fbank.shape[0], fbank.shape[1]) * np.random.rand() / 10

--- a/src/get_norm_stats.py
+++ b/src/get_norm_stats.py
@@ -10,10 +10,12 @@
 import torch
 import numpy as np
 
-audio_conf = {'num_mel_bins': 128, 'target_length': 1024, 'freqm': 24, 'timem': 192, 'mixup': 0.5}
+from src import dataloader
+
+audio_conf = {'num_mel_bins': 128, 'target_length': 1024, 'freqm': 24, 'timem': 192, 'mixup': 0.5, 'get_norm_stats': True, 'mode': 'train', 'dataset': 'audioset'}
 
 train_loader = torch.utils.data.DataLoader(
-    dataloaders.AudiosetDataset('/data/sls/scratch/yuangong/audioset/datafiles/balanced_train_data.json', label_csv='/data/sls/scratch/yuangong/audioset/utilities/class_labels_indices.csv',
+    dataloader.AudiosetDataset('/data/sls/scratch/yuangong/audioset/datafiles/balanced_train_data.json', label_csv='/data/sls/scratch/yuangong/audioset/utilities/class_labels_indices.csv',
                                 audio_conf=audio_conf), batch_size=1000, shuffle=False, num_workers=8, pin_memory=True)
 mean=[]
 std=[]


### PR DESCRIPTION
While evaluating the normalization stats, I was getting some small errors related to the `audio_conf` configuration. I have added the relevant fixes and now I am able to get the stats without any problem.

Problem summary
1. The values of `dataset` and  `mode` was not provided in the  `audio_conf`.
2. Since we are processing the dataset to get the normalization stats, we can't give the values of mean and std to the dataloader. I have added an extra config parameter `get_norm_stats` and enclosed [this](https://github.com/YuanGongND/ast/blob/87b81895ee866e5be451a5c139751735f836df76/src/dataloader.py#L191) line  in an if statement with `get_norm_stats`.